### PR TITLE
Improve consistency of cleanup code

### DIFF
--- a/ksql.c
+++ b/ksql.c
@@ -1161,6 +1161,7 @@ ksql_alloc_child(const struct ksqlcfg *cfg,
 	}
 	p->daemon = calloc(1, sizeof(struct ksqld));
 	if (NULL == p->daemon) {
+		close(comm);
 		ksql_free(p);
 		exit(EXIT_FAILURE);
 	}


### PR DESCRIPTION
Added for consistency, but inconsequential because we are exiting anyway.